### PR TITLE
Add DL libs to library list if building with Lua

### DIFF
--- a/config/project.cmake
+++ b/config/project.cmake
@@ -90,7 +90,7 @@ endif()
 if(RISTRA_ENABLE_LUA)
    message (STATUS "Found Lua: ${LUA_INCLUDE_DIR}")
    include_directories(${LUA_INCLUDE_DIR})
-   list(APPEND RISTRA_LIBRARIES ${LUA_LIBRARIES})
+   list(APPEND RISTRA_LIBRARIES ${LUA_LIBRARIES} ${CMAKE_DL_LIBS})
 endif ()
 
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
lua/5.3.4 on Darwin has a dependency on libdll.so, but this wasn't reflected on the link line.  This PR adds that dependency.
