### PR TITLE
Fix init value const

### DIFF
--- a/ristra/initialization/CMakeLists.txt
+++ b/ristra/initialization/CMakeLists.txt
@@ -31,7 +31,7 @@ set(initialization_SOURCES
 # Unit tests.
 #------------------------------------------------------------------------------#
 
-cinch_add_unit(ristra-test
+cinch_add_unit(ristra_initialization
   SOURCES
     test/test-announce.cc
     test/init_value.cc

--- a/ristra/initialization/init_value.h
+++ b/ristra/initialization/init_value.h
@@ -82,7 +82,7 @@ class init_value_t
     return t;
   }
 
-  status_t & status() const { return m_status; }
+  status_t const & status() const { return m_status; }
 
   /**\brief Has this init_value been resolved?
    * Does not throw.*/


### PR DESCRIPTION
Fixes error in initialization/init_value.h that only surfaced with GCC 8.1