### PR TITLE
Added OneOf, which asserts that the first argument is an element of t…

### DIFF
--- a/ristra/assertions/dbc.h
+++ b/ristra/assertions/dbc.h
@@ -10,6 +10,7 @@
 #include "ristra/assertions/detail/dbc_impl.h"
 #undef IM_OK_TO_INCLUDE_DBC_IMPL
 #include <functional>
+#include <set>
 #include <sstream>
 #include <string>
 
@@ -162,6 +163,20 @@ inline bool less_than_func(gt_t const & x, gt_t const & min, char const * name,
   return cond;
 } // GreaterThan
 
+template <typename T, typename container_t = std::set<T>>
+inline bool one_of_func(T const &key, container_t const &c, char const * name,
+  const char * file_name, const char * func_name, int line){
+  size_t count = c.count(key);
+  bool cond = count > 0;
+  auto gen = [&](){
+    std::stringstream errstr;
+    errstr << name << " not in set";
+    return errstr.str();
+  };
+  assertf_l(cond, gen, file_name, func_name, line, dbc_action);
+  return cond;
+} // OneOf
+
 } // namespace dbc
 } // namespace exception
 } // namespace ristra
@@ -172,6 +187,7 @@ inline bool less_than_func(gt_t const & x, gt_t const & min, char const * name,
     ristra::assertions::dbc::dbc_action);
 
 #ifdef RISTRA_REQUIRE_ON
+
 /*! \def Require(condition,descriptive_string): Precondition assertion. */
 #define Require(c, cs)    \
   ristra::assertions::dbc::assertf( \
@@ -207,6 +223,10 @@ inline bool less_than_func(gt_t const & x, gt_t const & min, char const * name,
 #define LessThan(x, mx) \
   ristra::assertions::dbc::less_than_func(x, mx, #x, __FILE__, __FUNCTION__, \
       __LINE__);
+/*! \def OneOf(x,set): Assert x element of set */
+#define OneOf(x, set) \
+  (ristra::assertions::dbc::one_of_func((x), (set), #x, __FILE__, __FUNCTION__, \
+      __LINE__));
 
 #else // REQUIRE_ON
 
@@ -218,6 +238,7 @@ inline bool less_than_func(gt_t const & x, gt_t const & min, char const * name,
 #define GreaterThan(x, mn) ((x) > (mn))
 #define GreaterEqual(x, mn) ((x) >= (mn))
 #define LessThan(x, mn) ((x) < (mn))
+#define OneOf(x,set) (true)
 
 #endif // REQUIRE_ON
 

--- a/ristra/assertions/test/dbc_test.cc
+++ b/ristra/assertions/test/dbc_test.cc
@@ -9,6 +9,7 @@
 
 #include "cinchtest.h"
 #include<ristra-config.h>
+#include <set>
 
 /* Test will take control of the test environment */
 #ifndef RISTRA_REQUIRE_ON
@@ -44,6 +45,36 @@ inline bool check_messages(std::string const & s1, std::string const & s2)
   }
   return msg_ok;
 } // check_messages
+
+TEST(dbc, OneOf){
+  std::string key("Key1");
+  int fail_line = -1;
+  try{
+    std::set<std::string> set1{key,"Key2","something else"};
+    bool retval1 = OneOf(key,set1);
+    EXPECT_TRUE(retval1);
+    // clang-format off
+    std::set<std::string> set2{"Key3","something completely different"};
+    fail_line = __LINE__; bool retval2 = OneOf(key,set2);
+    // clang-format on
+#if (defined RISTRA_REQUIRE_ON && defined RISTRA_DBC_THROW)
+    // Should not get here with exceptions
+    EXPECT_TRUE(false);
+#elif defined RISTRA_REQUIRE_ON
+    EXPECT_EQ(false, retval2);
+#else
+    EXPECT_EQ(true, retval2);
+#endif
+
+  } catch (std::exception & e) {
+    // exact message depends on build details. This part shd be invariant:
+    std::stringstream exp_msg;
+    exp_msg << __FILE__ << ":" << fail_line
+            << ":TestBody assertion 'key not in set' failed";
+    std::string excmsg(e.what());
+    EXPECT_TRUE(check_messages(exp_msg.str(), excmsg));
+    }
+} // TEST(dbc, OneOf)
 
 TEST(dbc, Equal)
 {

--- a/ristra/assertions/test/dbc_test_notify.cc
+++ b/ristra/assertions/test/dbc_test_notify.cc
@@ -63,6 +63,33 @@ inline bool check_messages(std::string const & s1, std::string const & s2)
   return msg_ok;
 } // check_messages
 
+TEST(dbc_notify, OneOf){
+  std::string key("Key1");
+  int fail_line = -1;
+  std::stringstream outs;
+  divert_stream(&outs);
+  try{
+    std::set<std::string> set1{key,"Key2","something else"};
+    bool retval1 = OneOf(key,set1);
+    EXPECT_TRUE(retval1);
+    // clang-format off
+    std::set<std::string> set2{"Key3","something completely different"};
+    fail_line = __LINE__; bool retval2 = OneOf(key,set2);
+    // clang-format on
+    EXPECT_FALSE(retval2);
+    std::string fail_msg(outs.str());
+    std::stringstream exp_msg;
+    exp_msg << __FILE__ << ":" << fail_line
+            << ":TestBody assertion 'key not in set' failed";
+    EXPECT_TRUE(check_messages(exp_msg.str(), fail_msg));
+  } catch (std::exception & e) {
+    printf("%s:%i: With DBC notify enabled, no exception should be thrown!!\n",
+      __FUNCTION__, __LINE__);
+    EXPECT_TRUE(false); // should not get here!
+  }
+  restore_stream();
+} // TEST(dbc_notify, OneOf)
+
 TEST(dbc_notify, Equal)
 {
   int i = 1;


### PR DESCRIPTION
…he second.

# Overview
Adds another DBC assertion (same level as Require), asserting that its first argument is an element of the second. For example, one might assert that the mesh input option is one of {"box","file"}.

# Detailed changes
Updated dbc.h and all three unit tests.