### PR TITLE
Feature/add is ostream writeable

### DIFF
--- a/config/project.cmake
+++ b/config/project.cmake
@@ -27,11 +27,11 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 set(CINCH_HEADER_SUFFIXES "\\.h")
 
 #------------------------------------------------------------------------------#
-# If a C++14 compiler is available, then set the appropriate flags
+# If a C++17 compiler is available, then set the appropriate flags
 #------------------------------------------------------------------------------#
 
-# We need C++ 14
-set(CMAKE_CXX_STANDARD 14)
+# We need C++ 17
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 set(CMAKE_CXX_EXTENSIONS off)
 

--- a/ristra/utils/test/type_traits_helpers.cc
+++ b/ristra/utils/test/type_traits_helpers.cc
@@ -155,4 +155,23 @@ TEST(type_traits, subscriptable)
 
 } // TEST(type_traits,subscriptable)
 
+struct Foo{};
+
+struct Zoo{
+  friend std::ostream & operator<<(std::ostream & s, Zoo const &) { return s; }
+};
+
+TEST(type_traits, is_ostream_writeable)
+{
+  bool constexpr case1_result = is_ostream_writeable<int>();
+  EXPECT_TRUE(case1_result);
+
+  bool constexpr case2_result = is_ostream_writeable<Foo>();
+  EXPECT_FALSE(case2_result);
+
+  bool constexpr case3_result = is_ostream_writeable<Zoo>();
+  EXPECT_TRUE(case3_result);
+
+} // TEST(type_traits, is_ostream_writeable)
+
 // End of file

--- a/ristra/utils/test/type_traits_helpers.cc
+++ b/ristra/utils/test/type_traits_helpers.cc
@@ -9,6 +9,7 @@
 // some containers that yeild interesting types
 #include <array>
 #include <map>
+#include <memory>
 #include <vector>
 
 using namespace ristra::utils;
@@ -154,6 +155,33 @@ TEST(type_traits, subscriptable)
   EXPECT_FALSE(case9_ok);
 
 } // TEST(type_traits,subscriptable)
+
+///////////////////////////////////////////////////////////////////////////////
+// Tests of is_iterator
+///////////////////////////////////////////////////////////////////////////////
+TEST(type_traits, is_iterator){
+  std::vector<int> v;
+  constexpr bool case1_result = is_iterator_v<decltype(v.begin())>;
+  EXPECT_TRUE(case1_result);
+
+  constexpr bool case2_result = is_iterator_v<int>;
+  EXPECT_FALSE(case2_result);
+
+  // a pointer can be used with any iterator algorithm
+  constexpr bool case3_result = is_iterator_v<int *>;
+  EXPECT_TRUE(case3_result);
+
+  // a shared pointer cannot be used with any iterator algorithm
+  constexpr bool case4_result = is_iterator_v<std::shared_ptr<int>>;
+  EXPECT_FALSE(case4_result);
+} // TEST(type_traits, is_iterator){
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Tests of is_ostream_writeable
+///////////////////////////////////////////////////////////////////////////////
+
 
 struct Foo{};
 

--- a/ristra/utils/type_traits.h
+++ b/ristra/utils/type_traits.h
@@ -95,6 +95,25 @@ template <typename T>
 constexpr bool is_container_v = is_container<T>::value;
 
 ////////////////////////////////////////////////////////////////////////////////
+//! \brief Check if a particular type T can be written a std::ostream.
+//! \remark If "strm << t" doesn't work, this version is instantiated.
+////////////////////////////////////////////////////////////////////////////////
+template <typename T,  typename = void>
+struct is_ostream_writeable : std::false_type{};
+
+////////////////////////////////////////////////////////////////////////////////
+//! \remark If "strm << t" works, this version is instantiated.
+////////////////////////////////////////////////////////////////////////////////
+template <typename T>
+struct is_ostream_writeable<T,
+  std::void_t<decltype(std::declval<std::ostream &>() << std::declval<T>())>>
+  : std::true_type {
+};
+
+template <typename T>
+constexpr bool is_ostream_writeable_v = is_ostream_writeable<T>();
+
+////////////////////////////////////////////////////////////////////////////////
 /// \brief A Helper to identify if this is a container
 //! \remark If T is, this version is instantiated.
 //! \remark This version uses to a reduced set of requirements for a container.


### PR DESCRIPTION
# Overview

Added a new static type predicate, whether a type can be written to a std::ostream.

# Details
Uses C++17 library feature std::void_t. Updated a few things that were using essentially the same construct. Added / expanded unit tests.