### PR TITLE
Add specialization of inverse for a 1x1 matrix

### DIFF
--- a/ristra/math/matrix.h
+++ b/ristra/math/matrix.h
@@ -172,6 +172,16 @@ auto determinant( const matrix<T, 1, 1> & mat )
 ////////////////////////////////////////////////////////////////////////////////
 //! @{
 template < typename T >
+auto inverse( const matrix<T, 1, 1> & mat )
+{
+  matrix<T,1,1> tmp;
+  auto a = mat(0,0);
+  assert( a != T() );
+  tmp(0,0) = T(1) / a;
+  return tmp;
+}
+
+template < typename T >
 auto inverse( const matrix<T, 2, 2> & mat )
 {
   matrix<T,2,2> tmp;

--- a/ristra/math/test/matrix.cc
+++ b/ristra/math/test/matrix.cc
@@ -396,3 +396,30 @@ TEST(matrix, divide_2d) {
   ASSERT_TRUE( g == ans ) << " error in operator/ with scalar";
  
 }
+
+///////////////////////////////////////////////////////////////////////////////
+//! \brief Test the inverse of a one-by-one matrix.
+///////////////////////////////////////////////////////////////////////////////
+TEST(matrix, invert_1d) {
+
+  matrix<real_t,1,1> a{ 4.0 };
+  matrix<real_t,1,1> ans{ 0.25 }; 
+
+  auto ainv = inverse(a);
+  ASSERT_TRUE( ainv == ans ) << " error in inverse(matrix)";
+  
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//! \brief Test the inverse of a two-by-two matrix.
+///////////////////////////////////////////////////////////////////////////////
+TEST(matrix, invert_2d) {
+
+  matrix<real_t,2,2> a{ 1.0, 2.0, 3.0, 4.0 };
+  matrix<real_t,2,2> ans{ -2.0, 1.0, 1.5, -0.5 };
+
+  auto ainv = inverse(a);
+  ASSERT_TRUE( ainv == ans ) << " error in inverse(matrix)";
+  
+}
+


### PR DESCRIPTION
I tried building a 1D hydro, but the 1D matrix solve would not build because a 1D inverse function was missing.  Instead the general NxN inverse was called, which tried to evaluate a 0x0 determinant and fell into a nasty infinite recursion...  This commit fixes that.